### PR TITLE
Dev 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
     - [Hyperledger-Fabric-Out](#hyperledger-fabric-out)
     - [Hyperledger-Fabric-Mid](#hyperledger-fabric-mid)
     - [Hyperledger-Fabric-In](#hyperledger-fabric-in)
-    - [Hyperledger-Fabric-Event-List](#hyperledger-fabric-event-list)
-    - [Hyperledger-Fabric-Query](#hyperledger-fabric-query)
   - [License <a name="license"></a>](#license-a-name%22license%22a)
 # node-red-contrib-fabric
 A set of nodes for interacting with Hyperledger Fabric
@@ -14,36 +12,10 @@ A set of nodes for interacting with Hyperledger Fabric
 A node red output node that allows you to submit or evaluate a transaction.
 
 ### Hyperledger-Fabric-Mid
-A node red mid flow node that allows you to submit or evaluate a transaction and get the result.
+A node red mid flow node that allows you to submit or evaluate a transaction and get the result, query the world state, listen for event(s), query a block by its number and query a transaction by its ID.
 
 ### Hyperledger-Fabric-In
 A node red input node that subscribes to events from a blockchain.
-
-### Hyperledger-Fabric-Event-List
-This node is an evolution of the Hyperledger-Fabric-In node.
-
-A node red mid flow that allows you to subscribe to events from a blockchain on a block interval
-
-This node can be configured manually or dynamically with the input payload. The input payload overwrites the manual configuration. 
-
-You can use manual node configuration AND dynamic configuration at the same time. The manual configuration properties will be overwriten by those provided in the ``msg.payload`` input message.
-
-This node allows to listen on a specific range of blocks.
-
-This node allows to setup a two seconds timeout to unregister the event listener. 
-
-Note: Currently it seems mandatory due to a [bug](https://jira.hyperledger.org/browse/FABN-1207) with the chaincode event listener options.
-
-The node behaves differently depending on how you use it:
-- If the node is configured to listen indefinitely (no timeout, no end block), events are pushed one by one to the next node.
-- If the node is configured to listen on a specific range of block (with an end block, with a timeout), once the timeout is reached, it will return all events in an array to the next node.
-- If the node is configured to listen on a specific range of block (with an end block, no timeout), events are pushed one by one to the next node. (Warning: If you specify a block higher than the current higher block, events located in new blocks won't be found)
-
-### Hyperledger-Fabric-Query
-A node red mid flow that allows you to query the blockchain world state.
-
-This node cand be configured dynamicaly with an input payload.
-
 
 ## License <a name="license"></a>
 Hyperledger Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the [LICENSE](LICENSE.txt) file. Hyperledger Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.

--- a/nodes/fabric.html
+++ b/nodes/fabric.html
@@ -149,7 +149,8 @@ limitations under the License.
                 <li>The arguments should be an array of strings</li>
                 <li>The name of the transaction should be set like <code>msg.payload.transactionName</code></li>
                 <li>The type of action the node should perform (<code>submit</code> or <code>evaluate</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
-                <li>Example: <code>{"transactionArgs": ["Arg1","Arg2","Arg3",],"transactionName": "myTransactionName","actionType": "submit"}</code> </li>
+                <li>Example: <code>{"transactionArgs": ["ARG0","ARG1","etc."],"transactionName": "myTxName","actionType": "submit","contractName": "myContractName"
+                }</code> </li>
             </ul>
         </li>
         <li>Query
@@ -158,21 +159,20 @@ limitations under the License.
                 <li>The arguments should be an array of strings</li>
                 <li>The type of action the node should perform (<code>query</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
                 <li>The name of the function to use in the chaincode should be set like <code>msg.payload.queryFcn</code> </li>
-                <li>Example: <code>{"queryArgs": ["myAssetKey"],"queryFcn": "query","actionType": "query"}</code> </li>
+                <li>Example: <code>{"queryArgs":["myArg", "etc."],"queryFcn":"myQueryFunction","actionType":"query","contractName":"contractName"}</code> </li>
             </ul>
         </li>
         <li>Event
             <ul>
                 <li>The timeout allows you to change the way the results are sent back to you. It is <code>"true"</code> by default. When <code>"true"</code>, it returns the events all at once in an array. When it is <code>"false"</code>, it returns the events
-                    one by one in <code>msg.payload</code></li>
+                    one by one in <code>msg.payload</code> and will not stop to listen</li>
                 <li><code>"startBlock"</code> and <code>"endBlock"</code> can be specified. When not, starts from 0 and never stops.</li>
                 <li><code>"eventName"</code> is the name of the event to match. Keep in mind that it accepts regular expressions.</li>
                 <li><code>"contractName"</code> is the name of the contract (chaincode) to listen events on.</li>
-                <li><code>"walletLocation"</code> is the path to the wallet on your file system. Be aware,even on Windows, it should be set with slashes and not backslashes.</li>
                 <li><code>"orgName"</code> is the name of the organization of the peer you connect to</li>
                 <li><code>"peerName"</code> is the name of the peer you connect to</li>
                 <li>The type of action the node should perform (<code>event</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
-                <li>Example: <code>{"startBlock":"0","endBlock":"100","timeout":"true","eventName":"myEventName","contractName":"myContractName","actionType":"event","walletLocation":"path/to/wallet/admin","orgName":"org1","peerName":"peer1"}</code> </li>
+                <li>Example: <code>{"startBlock": "myStartBlock","endBlock": "myEndBlock","timeout": "myTimeout","eventName": "myEventName","contractName": "myContractName","actionType": "event","orgName": "myOrgName","peerName": "myPeerName"}</code></li>
             </ul>
         </li>
     </ul>
@@ -180,14 +180,14 @@ limitations under the License.
         <ul>
             <li>The type of action the node should perform (<code>block</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
             <li>The number of the block to use should be set like <code>msg.payload.blockNumber</code>.
-                <li>Example: <code>{"actionType": "block","walletLocation": "C:/Users/FlorianCastelain/Documents/GitHub/blockchain-code/node-red/fabric-server/config/admin","orgName": "org1","peerName": "peer1","blockNumber": 10}</code> </li>
+                <li>Example: <code>{"actionType": "block","orgName": "myOrgName","peerName": "myPeerName","blockNumber": myBlockNumber}</code> </li>
         </ul>
         </li>
         <li>transaction
             <ul>
                 <li>The type of action the node should perform (<code>transaction</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
                 <li>The name of the function to use in the chaincode should be set like <code>msg.payload.queryFcn</code> </li>
-                <li>Example: <code>{"actionType": "transaction","walletLocation": "C:/Users/FlorianCastelain/Documents/GitHub/blockchain-code/node-red/fabric-server/config/admin","orgName": "org1","peerName": "peer1","transactionId": "6e05e896675816e1ccb6e24235fc9fcfa6172925c40281e829cf85f0cb59f830"}</code>                    </li>
+                <li>Example: <code>{"actionType": "transaction","orgName": "myOrgName","peerName": "myPeerName","transactionId": "myTxId"}</code> </li>
             </ul>
         </li>
         <p>Data returned from a transaction will be in <code>msg.payload</></p>

--- a/nodes/fabric.html
+++ b/nodes/fabric.html
@@ -19,17 +19,17 @@ limitations under the License.
 
     <div class="form-row">
         <label for="node-input-connection"><i class="fa"></i>Connection</label>
-        <input type="select" id="node-input-connection" placeholder="Connection"/>
+        <input type="select" id="node-input-connection" placeholder="Connection" />
     </div>
 
-     <div class="form-row">
+    <div class="form-row">
         <label for="node-input-channelName"><i class="fa"></i>Channel Name</label>
-        <input type="text" id="node-input-channelName" placeholder=""/>
+        <input type="text" id="node-input-channelName" placeholder="" />
     </div>
 
     <div class="form-row">
         <label for="node-input-contractName"><i class="fa"></i>Contract Name</label>
-        <input type="text" id="node-input-contractName" placeholder=""/>
+        <input type="text" id="node-input-contractName" placeholder="" />
     </div>
 
     <div class="form-row">
@@ -48,22 +48,22 @@ limitations under the License.
 
     <div class="form-row">
         <label for="node-input-connection"><i class="fa"></i>Connection</label>
-        <input type="select" id="node-input-connection" placeholder="Connection"/>
+        <input type="select" id="node-input-connection" placeholder="Connection" />
     </div>
 
-     <div class="form-row">
+    <div class="form-row">
         <label for="node-input-channelName"><i class="fa"></i>Channel Name</label>
-        <input type="text" id="node-input-channelName" placeholder=""/>
+        <input type="text" id="node-input-channelName" placeholder="" />
     </div>
 
     <div class="form-row">
         <label for="node-input-contractName"><i class="fa"></i>Contract Name</label>
-        <input type="text" id="node-input-contractName" placeholder=""/>
+        <input type="text" id="node-input-contractName" placeholder="" />
     </div>
 
     <div class="form-row">
         <label for="node-input-actionType"><i class="fa"></i>Action Type</label>
-        <select id="node-input-actionTypeForm">
+        <select id="node-input-actionType">
             <option value="submit">Submit Transaction</option>
             <option value="evaluate">Evaluate Transaction</option>
             <option value="query">Query Worldstate</option>
@@ -81,44 +81,57 @@ limitations under the License.
     </div>
     <div class="form-row">
         <label for="node-input-connection"><i class="fa"></i>Connection</label>
-        <input type="select" id="node-input-connection" placeholder="Connection"/>
+        <input type="select" id="node-input-connection" placeholder="Connection" />
     </div>
-     <div class="form-row">
+    <div class="form-row">
         <label for="node-input-channelName"><i class="fa"></i>Channel Name</label>
-        <input type="text" id="node-input-channelName" placeholder=""/>
+        <input type="text" id="node-input-channelName" placeholder="" />
     </div>
     <div class="form-row">
         <label for="node-input-contractName"><i class="fa"></i>Contract Name</label>
-        <input type="text" id="node-input-contractName" placeholder=""/>
+        <input type="text" id="node-input-contractName" placeholder="" />
     </div>
     <div class="form-row">
         <label for="node-input-eventName"><i class="fa"></i>Event Name</label>
-        <input type="text" id="node-input-eventName" placeholder=".*"/>
+        <input type="text" id="node-input-eventName" placeholder=".*" />
     </div>
 </script>
 <script type="text/x-red" data-help-name="fabric-out">
-  <p>Hyperledger Fabric output node. Submit or evaluate transactions</p>
-  <p>The name of the transaction should be set like <code>msg.payload.transactionName</code></p>
-  <p>The arguments for the transaction should be set like <code>msg.payload.args</code>. The arguments should be an array of strings</p>
-  <p>For example <code>{"transactionName: "myTransaction", "args": ["arg1", "arg2"]}</code></p>
+    <p>Hyperledger Fabric output node. Submit or evaluate transactions</p>
+    <p>The name of the transaction should be set like <code>msg.payload.transactionName</code></p>
+    <p>The arguments for the transaction should be set like <code>msg.payload.args</code>. The arguments should be an array of strings</p>
+    <p>For example <code>{"transactionName: "myTransaction", "args": ["arg1", "arg2"]}</code></p>
 </script>
 <script type="text/javascript">
     RED.nodes.registerType('fabric-out', {
-        category : 'Hyperledger',
-        color : '#E6E0F8',
-        paletteLabel : 'Hyperledger Fabric - Out',
-        defaults : {
-            name : {value : ''},
-            connection : {value : '', type : 'fabric-config'},
-            channelName : {value : '', required : true},
-            contractName : {value : '', required : true},
-            actionType : {value : 'submit'}
+        category: 'Hyperledger',
+        color: '#E6E0F8',
+        paletteLabel: 'Hyperledger Fabric - Out',
+        defaults: {
+            name: {
+                value: ''
+            },
+            connection: {
+                value: '',
+                type: 'fabric-config'
+            },
+            channelName: {
+                value: '',
+                required: true
+            },
+            contractName: {
+                value: '',
+                required: true
+            },
+            actionType: {
+                value: 'submit'
+            }
         },
-        inputs : 1,
-        outputs : 0,
-        icon : 'icon.png',
-        align : 'right',
-        label : function () {
+        inputs: 1,
+        outputs: 0,
+        icon: 'icon.png',
+        align: 'right',
+        label: function() {
             return this.name || 'Hyperledger Fabric - Out';
         }
     });
@@ -126,63 +139,91 @@ limitations under the License.
 
 <!-- TODO update with queryTransaction and queryBlock -->
 <script type="text/x-red" data-help-name="fabric-mid">
-<p>Hyperledger Fabric mid node. Submit or evaluate transactions, query world state and listen for events</p>
+    <p>Hyperledger Fabric mid node. Submit or evaluate transactions, query world state, listen for events, query a block or query a transaction</p>
 
 
-  <ul>
-    <li>Submit/evaluate
-      <ul>
-        <li>the arguments for the transaction should be set like <code>msg.payload.transactionArgs</code>.</li>
-        <li>The arguments should be an array of strings</li>
-        <li>The name of the transaction should be set like <code>msg.payload.transactionName</code></li>
-        <li>The type of transaction (<code>submit</code> or <code>evaluate</code>) should be set like <code>msg.payload.actionTypeForm</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
-        <li>Example: <code>{"transactionArgs": ["Arg1","Arg2","Arg3",],"transactionName": "myTransactionName","actionTypeForm": "submit"}</code> </li>
-    </ul>
-    </li>
-    <li>Query
-        <ul>
-          <li>the arguments for the transaction should be set like <code>msg.payload.queryArgs</code>.</li>
-          <li>The arguments should be an array of strings</li>
-          <li>The type of transaction (<code>query</code>) should be set like <code>msg.payload.actionTypeForm</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
-          <li>The name of the function to use in the chaincode should be set like <code>msg.payload.queryFcn</code> </li>
-          <li>Example: <code>{"queryArgs": ["myAssetKey"],"queryFcn": "query","actionTypeForm": "query"}</code> </li>
-        </ul>
-      </li>
-      <li>Event
+    <ul>
+        <li>Submit/evaluate
             <ul>
-              <li>The timeout allows you to change the way the results are sent back to you. It is <code>"true"</code> by default. When <code>"true"</code>, it returns the events all at once in an array. When it is <code>"false"</code>, it returns the events one by one in <code>msg.payload</code></li>
-              <li><code>"startBlock"</code> and <code>"endBlock"</code> can be specified. When not, starts from 0 and never stops.</li>
-              <li><code>"eventName"</code> is the name of the event to match. Keep in mind that it accepts regular expressions.</li>
-              <li><code>"contractName"</code> is the name of the contract (chaincode) to listen events on.</li>
-              <li><code>"walletLocation"</code> is the path to the wallet on your file system. Be aware,even on Windows, it should be set with slashes and not backslashes.</li>
-              <li><code>"orgName"</code> is the name of the organization of the peer you connect to</li>
-              <li><code>"peerName"</code> is the name of the peer you connect to</li>
-              <li>The type of transaction (<code>event</code>) should be set like <code>msg.payload.actionTypeForm</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
-              <li>Example: <code>{"startBlock":"0","endBlock":"100","timeout":"true","eventName":"myEventName","contractName":"myContractName","actionTypeForm":"event","walletLocation":"path/to/wallet/admin","orgName":"org1","peerName":"peer1"}</code> </li>
+                <li>the arguments for the transaction should be set like <code>msg.payload.transactionArgs</code>.</li>
+                <li>The arguments should be an array of strings</li>
+                <li>The name of the transaction should be set like <code>msg.payload.transactionName</code></li>
+                <li>The type of action the node should perform (<code>submit</code> or <code>evaluate</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+                <li>Example: <code>{"transactionArgs": ["Arg1","Arg2","Arg3",],"transactionName": "myTransactionName","actionType": "submit"}</code> </li>
             </ul>
-        </li> 
-</ul>
-  <p>Data returned from a transaction will be in <code>msg.payload</></p>
+        </li>
+        <li>Query
+            <ul>
+                <li>the arguments for the transaction should be set like <code>msg.payload.queryArgs</code>.</li>
+                <li>The arguments should be an array of strings</li>
+                <li>The type of action the node should perform (<code>query</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+                <li>The name of the function to use in the chaincode should be set like <code>msg.payload.queryFcn</code> </li>
+                <li>Example: <code>{"queryArgs": ["myAssetKey"],"queryFcn": "query","actionType": "query"}</code> </li>
+            </ul>
+        </li>
+        <li>Event
+            <ul>
+                <li>The timeout allows you to change the way the results are sent back to you. It is <code>"true"</code> by default. When <code>"true"</code>, it returns the events all at once in an array. When it is <code>"false"</code>, it returns the events
+                    one by one in <code>msg.payload</code></li>
+                <li><code>"startBlock"</code> and <code>"endBlock"</code> can be specified. When not, starts from 0 and never stops.</li>
+                <li><code>"eventName"</code> is the name of the event to match. Keep in mind that it accepts regular expressions.</li>
+                <li><code>"contractName"</code> is the name of the contract (chaincode) to listen events on.</li>
+                <li><code>"walletLocation"</code> is the path to the wallet on your file system. Be aware,even on Windows, it should be set with slashes and not backslashes.</li>
+                <li><code>"orgName"</code> is the name of the organization of the peer you connect to</li>
+                <li><code>"peerName"</code> is the name of the peer you connect to</li>
+                <li>The type of action the node should perform (<code>event</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+                <li>Example: <code>{"startBlock":"0","endBlock":"100","timeout":"true","eventName":"myEventName","contractName":"myContractName","actionType":"event","walletLocation":"path/to/wallet/admin","orgName":"org1","peerName":"peer1"}</code> </li>
+            </ul>
+        </li>
+    </ul>
+    <li>Block
+        <ul>
+            <li>The type of action the node should perform (<code>block</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+            <li>The number of the block to use should be set like <code>msg.payload.blockNumber</code>.
+                <li>Example: <code>{"actionType": "block","walletLocation": "C:/Users/FlorianCastelain/Documents/GitHub/blockchain-code/node-red/fabric-server/config/admin","orgName": "org1","peerName": "peer1","blockNumber": 10}</code> </li>
+        </ul>
+        </li>
+        <li>transaction
+            <ul>
+                <li>The type of action the node should perform (<code>transaction</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+                <li>The name of the function to use in the chaincode should be set like <code>msg.payload.queryFcn</code> </li>
+                <li>Example: <code>{"actionType": "transaction","walletLocation": "C:/Users/FlorianCastelain/Documents/GitHub/blockchain-code/node-red/fabric-server/config/admin","orgName": "org1","peerName": "peer1","transactionId": "6e05e896675816e1ccb6e24235fc9fcfa6172925c40281e829cf85f0cb59f830"}</code>                    </li>
+            </ul>
+        </li>
+        <p>Data returned from a transaction will be in <code>msg.payload</></p>
   <p>The <code>payload</code> will be a buffer and you will need to deserialize the data downstream</p>
-  <p>For example <code>msg.payload.toString()</code>
+        <p>For example <code>msg.payload.toString()</code>
 
 </script>
 <script type="text/javascript">
     RED.nodes.registerType('fabric-mid', {
-        category : 'Hyperledger',
-        color : '#E6E0F8',
-        paletteLabel : 'Hyperledger Fabric - Mid',
-        defaults : {
-            name : {value : ''},
-            connection : {value : '', type : 'fabric-config'},
-            channelName : {value : '', required : false},
-            contractName : {value : '', required : false},
-            actionTypeForm : {value : 'submit'}
+        category: 'Hyperledger',
+        color: '#E6E0F8',
+        paletteLabel: 'Hyperledger Fabric - Mid',
+        defaults: {
+            name: {
+                value: ''
+            },
+            connection: {
+                value: '',
+                type: 'fabric-config'
+            },
+            channelName: {
+                value: '',
+                required: false
+            },
+            contractName: {
+                value: '',
+                required: false
+            },
+            actionType: {
+                value: 'submit'
+            }
         },
-        inputs : 1,
-        outputs : 1,
-        icon : 'icon.png',
-        label : function () {
+        inputs: 1,
+        outputs: 1,
+        icon: 'icon.png',
+        label: function() {
             return this.name || 'Hyperledger Fabric - Mid';
         },
     });
@@ -192,25 +233,39 @@ limitations under the License.
     <p>Will create a message with the structure <code>{"eventName" : "myEvent", "payload": "myPayload"}</code></p>
     <p>The <code>payload</code> will be a buffer and you will need to deserialize the data downstream</p>
     <p>For example <code>msg.payload.toString()</code>
-  </script>
+</script>
 <script type="text/javascript">
-      RED.nodes.registerType('fabric-in', {
-          category: 'Hyperledger',
-          color: "#E6E0F8",
-          paletteLabel: "Hyperledger Fabric",
-          defaults: {
-              name: {value: ""},
-              connection : {value : '', type : 'fabric-config'},
-              channelName : {value : '', required : true},
-              contractName : {value : '', required : true},
-              eventName : {value : '.*', required : false},
-          },
-          inputs : 0,
-          outputs : 1,
-          icon : "icon.png",
-          align : "left",
-          label : function () {
-              return this.name || "Hyperledger Fabric";
-          }
-      });
+    RED.nodes.registerType('fabric-in', {
+        category: 'Hyperledger',
+        color: "#E6E0F8",
+        paletteLabel: "Hyperledger Fabric",
+        defaults: {
+            name: {
+                value: ""
+            },
+            connection: {
+                value: '',
+                type: 'fabric-config'
+            },
+            channelName: {
+                value: '',
+                required: true
+            },
+            contractName: {
+                value: '',
+                required: true
+            },
+            eventName: {
+                value: '.*',
+                required: false
+            },
+        },
+        inputs: 0,
+        outputs: 1,
+        icon: "icon.png",
+        align: "left",
+        label: function() {
+            return this.name || "Hyperledger Fabric";
+        }
+    });
 </script>

--- a/nodes/fabric.html
+++ b/nodes/fabric.html
@@ -68,6 +68,8 @@ limitations under the License.
             <option value="evaluate">Evaluate Transaction</option>
             <option value="query">Query Worldstate</option>
             <option value="event">Listen Event</option>
+            <option value="block">Query Block</option>
+            <option value="transaction">Query Transaction</option>
         </select>
     </div>
 
@@ -121,8 +123,10 @@ limitations under the License.
         }
     });
 </script>
+
+<!-- TODO update with queryTransaction and queryBlock -->
 <script type="text/x-red" data-help-name="fabric-mid">
-<p>Hyperledger Fabric mid node. Submit or evaluate transactions and query world state</p>
+<p>Hyperledger Fabric mid node. Submit or evaluate transactions, query world state and listen for events</p>
 
 
   <ul>

--- a/nodes/fabric.html
+++ b/nodes/fabric.html
@@ -66,7 +66,8 @@ limitations under the License.
         <select id="node-input-actionTypeForm">
             <option value="submit">Submit Transaction</option>
             <option value="evaluate">Evaluate Transaction</option>
-            <option value="query"> Query Worldstate </option>
+            <option value="query">Query Worldstate</option>
+            <option value="event">Listen Event</option>
         </select>
     </div>
 
@@ -91,81 +92,6 @@ limitations under the License.
     <div class="form-row">
         <label for="node-input-eventName"><i class="fa"></i>Event Name</label>
         <input type="text" id="node-input-eventName" placeholder=".*"/>
-    </div>
-</script>
-<script type="text/x-red" data-template-name="fabric-event-list">
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>
-    <div class="form-row">
-        <label for="node-input-connection"><i class="fa"></i>Connection</label>
-        <input type="select" id="node-input-connection" placeholder="Connection"/>
-    </div>
-
-     <div class="form-row">
-        <label for="node-input-channelName"><i class="fa"></i>Channel Name</label>
-        <input type="text" id="node-input-channelName" placeholder=""/>
-    </div>
-
-    <div class="form-row">
-        <label for="node-input-contractName"><i class="fa"></i>Contract Name</label>
-        <input type="text" id="node-input-contractName" placeholder=""/>
-    </div>
-
-    <div class="form-row">
-        <label for="node-input-eventName"><i class="fa"></i>Event Name</label>
-        <input type="text" id="node-input-eventName" placeholder=".*"/>
-    </div>
-    <div class="form-row">
-        <label for="node-input-startBlock"><i class="fa"></i>Start Block</label>
-        <input type="text" id="node-input-startBlock" placeholder=".*"/>
-    </div>
-    <div class="form-row">
-        <label for="node-input-endBlock"><i class="fa"></i>End Block</label>
-        <input type="text" id="node-input-endBlock" placeholder=".*"/>
-    </div>
-    <div class="form-row">
-        <label for="node-input-orgName"><i class="fa"></i>Org name</label>
-        <input type="text" id="node-input-orgName" placeholder=".*"/>
-    </div>
-    <div class="form-row">
-        <label for="node-input-peerName"><i class="fa"></i>Peer name</label>
-        <input type="text" id="node-input-peerName" placeholder=".*"/>
-    </div>
-    <div class="form-row">
-        <label for="node-input-walletLocation"><i class="fa"></i>Wallet location</label>
-        <input type="text" id="node-input-walletLocation" placeholder=".*"/>
-    </div>
-    <div class="form-row">
-        <label for="node-input-timeout"><i class="fa"></i>timeout</label>
-        <input type="text" id="node-input-timeout" placeholder=".*"/>
-    </div>
-</script>
-<script type="text/x-red" data-template-name="fabric-query">
-    <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
-    </div>
-
-    <div class="form-row">
-        <label for="node-input-connection"><i class="fa"></i>Connection</label>
-        <input type="select" id="node-input-connection" placeholder="Connection"/>
-    </div>
-
-     <div class="form-row">
-        <label for="node-input-channelName"><i class="fa"></i>Channel Name</label>
-        <input type="text" id="node-input-channelName" placeholder=""/>
-    </div>
-
-    <div class="form-row">
-        <label for="node-input-request"><i class="fa"></i>Request</label>
-        <input type="text" id="node-input-request" placeholder=""/>
-    </div>
-
-    <div class="form-row">
-        <label for="node-input-contractName"><i class="fa"></i>Chaincode name</label>
-        <input type="text" id="node-input-contractName" placeholder=""/>
     </div>
 </script>
 <script type="text/x-red" data-help-name="fabric-out">
@@ -205,20 +131,33 @@ limitations under the License.
         <li>the arguments for the transaction should be set like <code>msg.payload.transactionArgs</code>.</li>
         <li>The arguments should be an array of strings</li>
         <li>The name of the transaction should be set like <code>msg.payload.transactionName</code></li>
-        <li>The type of transaction (<code>submit</code> or <code>evaluate</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
-        <li>Example: <code>{"transactionArgs": ["Arg1","Arg2","Arg3",],"transactionName": "myTransactionName","actionType": "submit"}</code> </li>
+        <li>The type of transaction (<code>submit</code> or <code>evaluate</code>) should be set like <code>msg.payload.actionTypeForm</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+        <li>Example: <code>{"transactionArgs": ["Arg1","Arg2","Arg3",],"transactionName": "myTransactionName","actionTypeForm": "submit"}</code> </li>
     </ul>
     </li>
     <li>Query
         <ul>
           <li>the arguments for the transaction should be set like <code>msg.payload.queryArgs</code>.</li>
           <li>The arguments should be an array of strings</li>
-          <li>The type of transaction (<code>query</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+          <li>The type of transaction (<code>query</code>) should be set like <code>msg.payload.actionTypeForm</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
           <li>The name of the function to use in the chaincode should be set like <code>msg.payload.queryFcn</code> </li>
-          <li>Example: <code>{"queryArgs": ["myAssetKey"],"queryFcn": "query","actionType": "query"}</code> </li>
+          <li>Example: <code>{"queryArgs": ["myAssetKey"],"queryFcn": "query","actionTypeForm": "query"}</code> </li>
         </ul>
       </li>
-  </ul>
+      <li>Event
+            <ul>
+              <li>The timeout allows you to change the way the results are sent back to you. It is <code>"true"</code> by default. When <code>"true"</code>, it returns the events all at once in an array. When it is <code>"false"</code>, it returns the events one by one in <code>msg.payload</code></li>
+              <li><code>"startBlock"</code> and <code>"endBlock"</code> can be specified. When not, starts from 0 and never stops.</li>
+              <li><code>"eventName"</code> is the name of the event to match. Keep in mind that it accepts regular expressions.</li>
+              <li><code>"contractName"</code> is the name of the contract (chaincode) to listen events on.</li>
+              <li><code>"walletLocation"</code> is the path to the wallet on your file system. Be aware,even on Windows, it should be set with slashes and not backslashes.</li>
+              <li><code>"orgName"</code> is the name of the organization of the peer you connect to</li>
+              <li><code>"peerName"</code> is the name of the peer you connect to</li>
+              <li>The type of transaction (<code>event</code>) should be set like <code>msg.payload.actionTypeForm</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+              <li>Example: <code>{"startBlock":"0","endBlock":"100","timeout":"true","eventName":"myEventName","contractName":"myContractName","actionTypeForm":"event","walletLocation":"path/to/wallet/admin","orgName":"org1","peerName":"peer1"}</code> </li>
+            </ul>
+        </li> 
+</ul>
   <p>Data returned from a transaction will be in <code>msg.payload</></p>
   <p>The <code>payload</code> will be a buffer and you will need to deserialize the data downstream</p>
   <p>For example <code>msg.payload.toString()</code>
@@ -270,69 +209,4 @@ limitations under the License.
               return this.name || "Hyperledger Fabric";
           }
       });
-</script>
-<script type="text/x-red" data-help-name="fabric-event-list">
-    <p>Hyperledger Fabric input node. Subscribe to events emitted by a blockchain</p>.
-    <p>Will create a message with the structure <code>{"eventName" : "myEvent", "payload": "myPayload"}</code></p>
-    <p>The <code>payload</code> will be a buffer and you will need to deserialize the data downstream</p>
-    <p>For example <code>msg.payload.toString()</code>
-    <p>The start block and end block are not required.</p>
-  </script>
-<script type="text/javascript">
-      RED.nodes.registerType('fabric-event-list', {
-          category: 'Hyperledger',
-          color: "#E6E0F8",
-          paletteLabel: "Hyperledger Fabric - Event list",
-          defaults: {
-              name: {value: ""},
-              connection : {value : '', type : 'fabric-config', required: true},
-              channelName : {value : '', required : false},
-              contractName : {value : '', required : false},
-              eventName : {value : '.*', required : false},
-              startBlock: {value: '', type: 'num', required: false},
-              endBlock: {value: '', type: 'num', required: false},
-              orgName: {value: '', type: 'text', required: false},
-              peerName: {value: '', type: 'text', required: false},
-              walletLocation: {value:'', type:'text', required: true},
-              timeout: {value: '', type: 'text', required: false}
-              
-          },
-          inputs : 1,
-          outputs : 1,
-          icon : "icon.png",
-          align : "left",
-          label : function () {
-              return this.name || "Hyperledger Fabric - Event list";
-          }
-      });
-  </script>
-<script type="text/x-red" data-help-name="fabric-query">
-    <p>Hyperledger Fabric query node. Query the ledger world state</p>
-    <p>This node returns a result, even if it is a chaincode error.</p>
-    <p>Any input payload will overwrite the manual configuration</p>
-    <p>The <code>request</code> parameter should be the following:</p>
-    <p>Simple query: <code>{"chaincodeId":"chaincodeName","fcn":"query","args":["myarg"]}</code></p>
-    <p>Rich query: <code> {"chaincodeId":"chaincodeName","fcn":"richQuery","args":["{ \"selector\": { \"field\": \"fieldValue\" } }"]}</code></p>
-    <p>Notice that for the rich query, the arg has been escaped. You must do it before sending it to this node</p>
-    <p>Remark: change the <code>fcn</code> property to suite the name of the query function you have in your chaincode</p>
-</script>
-<script type="text/javascript">
-        RED.nodes.registerType('fabric-query', {
-            category : 'Hyperledger',
-            color : '#E6E0F8',
-            paletteLabel : 'Hyperledger Fabric - Query',
-            defaults : {
-                name : {value : ''},
-                connection : {value : '', type : 'fabric-config'},
-                channelName : {value : '', required : false},
-                request: {value: '', required: false},
-                contractName: {value:'', required: false}
-                },
-            inputs : 1,
-            outputs : 1,
-            icon : 'icon.png',
-            label : function () {
-                return this.name || 'Hyperledger Fabric - Query';
-            }
-        });
 </script>

--- a/nodes/fabric.html
+++ b/nodes/fabric.html
@@ -63,11 +63,13 @@ limitations under the License.
 
     <div class="form-row">
         <label for="node-input-actionType"><i class="fa"></i>Action Type</label>
-        <select id="node-input-actionType">
+        <select id="node-input-actionTypeForm">
             <option value="submit">Submit Transaction</option>
             <option value="evaluate">Evaluate Transaction</option>
+            <option value="query"> Query Worldstate </option>
         </select>
     </div>
+
 </script>
 <script type="text/x-red" data-template-name="fabric-in">
     <div class="form-row">
@@ -194,13 +196,33 @@ limitations under the License.
     });
 </script>
 <script type="text/x-red" data-help-name="fabric-mid">
-<p>Hyperledger Fabric mid node. Submit or evaluate transactions</p>
-  <p>The name of the transaction should be set like <code>msg.payload.transactionName</code></p>
-  <p>The arguments for the transaction should be set like <code>msg.payload.args</code>. The arguments should be an array of strings</p>
-  <p>For example <code>{"transactionName: "myTransaction", "args": ["arg1", "arg2"]}</code></p>
+<p>Hyperledger Fabric mid node. Submit or evaluate transactions and query world state</p>
+
+
+  <ul>
+    <li>Submit/evaluate
+      <ul>
+        <li>the arguments for the transaction should be set like <code>msg.payload.transactionArgs</code>.</li>
+        <li>The arguments should be an array of strings</li>
+        <li>The name of the transaction should be set like <code>msg.payload.transactionName</code></li>
+        <li>The type of transaction (<code>submit</code> or <code>evaluate</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+        <li>Example: <code>{"transactionArgs": ["Arg1","Arg2","Arg3",],"transactionName": "myTransactionName","actionType": "submit"}</code> </li>
+    </ul>
+    </li>
+    <li>Query
+        <ul>
+          <li>the arguments for the transaction should be set like <code>msg.payload.queryArgs</code>.</li>
+          <li>The arguments should be an array of strings</li>
+          <li>The type of transaction (<code>query</code>) should be set like <code>msg.payload.actionType</code>. The value set in the node will be overwritten by the value in <code>msg.payload</code></li>
+          <li>The name of the function to use in the chaincode should be set like <code>msg.payload.queryFcn</code> </li>
+          <li>Example: <code>{"queryArgs": ["myAssetKey"],"queryFcn": "query","actionType": "query"}</code> </li>
+        </ul>
+      </li>
+  </ul>
   <p>Data returned from a transaction will be in <code>msg.payload</></p>
   <p>The <code>payload</code> will be a buffer and you will need to deserialize the data downstream</p>
   <p>For example <code>msg.payload.toString()</code>
+
 </script>
 <script type="text/javascript">
     RED.nodes.registerType('fabric-mid', {
@@ -212,14 +234,14 @@ limitations under the License.
             connection : {value : '', type : 'fabric-config'},
             channelName : {value : '', required : false},
             contractName : {value : '', required : false},
-            actionType : {value : 'submit'}
+            actionTypeForm : {value : 'submit'}
         },
         inputs : 1,
         outputs : 1,
         icon : 'icon.png',
         label : function () {
             return this.name || 'Hyperledger Fabric - Mid';
-        }
+        },
     });
 </script>
 <script type="text/x-red" data-help-name="fabric-in">

--- a/nodes/fabric.js
+++ b/nodes/fabric.js
@@ -13,7 +13,7 @@
  */
 
 'use strict';
-module.exports = function (RED) {
+module.exports = function(RED) {
     const util = require('util');
     const fabricNetwork = require('fabric-network');
     const fabricClient = require('fabric-client');
@@ -79,12 +79,12 @@ module.exports = function (RED) {
     }
 
     /**
-    * 
-    * @param {Contract} contract contract
-    * @param {object} payload payload
-    * @param {Node} node node
-    * @returns {Promise<Buffer>} promise
-    */
+     * 
+     * @param {Contract} contract contract
+     * @param {object} payload payload
+     * @param {Node} node node
+     * @returns {Promise<Buffer>} promise
+     */
     function query(channel, payload, contractName, node) {
         node.log(`query ${contractName} ${payload.queryFcn} ${payload.queryArgs}`);
         return channel.queryByChaincode({
@@ -127,20 +127,20 @@ module.exports = function (RED) {
 
 
     /**
- * An event subscriber that subscribes to only one event and closes after a 2sec timeout if required
- * It also can listen on an interval of blocks, useful in cases you do not want to keep listenning
- * Sends all the events in an array or one by one in the msg.payload depending on the configuration
- * @param {peer} peer The peer to connect to
- * @param {channel} channel The channel on which create the event hub
- * @param {string} chaincodeName The name of the chaincode
- * @param {string} eventName The name of the event to listen to
- * @param {integer} startBlock The block to start listenning from (0 by default)
- * @param {integer} endBlock The last block to listen to (newest by default)
- * @param {Node} node node
- * @param {object} msg The msg object 
- * @param {boolean} timeout A parameter that specifies if the listener must timeout or not. This must be used if the purpose of the listener is to check for specific events on a specific range of blocks. Else, it will run forever
- * @returns {Promise<Buffer>} promise
- */
+     * An event subscriber that subscribes to only one event and closes after a 2sec timeout if required
+     * It also can listen on an interval of blocks, useful in cases you do not want to keep listenning
+     * Sends all the events in an array or one by one in the msg.payload depending on the configuration
+     * @param {peer} peer The peer to connect to
+     * @param {channel} channel The channel on which create the event hub
+     * @param {string} chaincodeName The name of the chaincode
+     * @param {string} eventName The name of the event to listen to
+     * @param {integer} startBlock The block to start listenning from (0 by default)
+     * @param {integer} endBlock The last block to listen to (newest by default)
+     * @param {Node} node node
+     * @param {object} msg The msg object 
+     * @param {boolean} timeout A parameter that specifies if the listener must timeout or not. This must be used if the purpose of the listener is to check for specific events on a specific range of blocks. Else, it will run forever
+     * @returns {Promise<Buffer>} promise
+     */
     async function subscribeToEvent(peer, channel, chaincodeName,
         eventName, startBlock, endBlock, node, msg, timeout = true) {
         let eventHub = channel.newChannelEventHub(peer);
@@ -186,8 +186,10 @@ module.exports = function (RED) {
             };
             // refresh timeout because we want ALL the events in the block interval
             // not only the ones in the time interval
-            if (timeout) { eventList.push(eventPayload); eventTimeout.refresh(); }
-            else { node.send(eventPayload); }
+            if (timeout) {
+                eventList.push(eventPayload);
+                eventTimeout.refresh();
+            } else { node.send(eventPayload); }
             node.status({});
             // node.send(msg);
         }, (error) => {
@@ -199,25 +201,36 @@ module.exports = function (RED) {
     }
 
 
-    //todo signature
-    async function queryBlock(channel, payload) {
-        return await channel.queryBlock(payload.blockNumber);
+    /**
+     *
+     * @param {object} channel the channel object
+     * @param {string} blockNumber the number of the block to get
+     * @returns {PromiseLike<Contract | never>} promise
+     */
+    async function queryBlock(channel, blockNumber) {
+        return await channel.queryBlock(blockNumber);
     }
 
+    /**
+     *
+     * @param {object} channel the channel object
+     * @param {string} transactionId the identifier of the transaction to get
+     * @returns {PromiseLike<Contract | never>} promise
+     */
     async function queryTransaction(channel, transactionId) {
         return await channel.queryTransaction(transactionId);
     }
 
     /**
- *
- * @param {string} identityName identityName
- * @param {string} channelName channel
- * @param {string} orgName name of the organization
- * @param {string} peerName name of the peer
- * @param {object} connectionProfile the connection profile as a json
- * @param {string} walletLocation the wallet location (the files, not the folder)
- * @returns {PromiseLike<Contract | never>} promise
- */
+     *
+     * @param {string} identityName identityName
+     * @param {string} channelName channel
+     * @param {string} orgName name of the organization
+     * @param {string} peerName name of the peer
+     * @param {object} connectionProfile the connection profile as a json
+     * @param {string} walletLocation the wallet location (the files, not the folder)
+     * @returns {PromiseLike<Contract | never>} promise
+     */
     async function connectToPeer(identityName, channelName,
         orgName, peerName, connectionProfile, walletLocation) {
         try {
@@ -258,7 +271,7 @@ module.exports = function (RED) {
         let node = this;
         RED.nodes.createNode(node, config);
 
-        node.on('input', async function (msg) {
+        node.on('input', async function(msg) {
             this.connection = RED.nodes.getNode(config.connection);
             try {
                 const identityName = node.connection.identityName;
@@ -295,7 +308,7 @@ module.exports = function (RED) {
         let node = this;
         RED.nodes.createNode(node, config);
 
-        node.on('input', async function (msg) {
+        node.on('input', async function(msg) {
             this.connection = RED.nodes.getNode(config.connection);
             try {
                 //node.log('config ' + util.inspect(node.connection, false, null));
@@ -326,8 +339,8 @@ module.exports = function (RED) {
                     node.send(msg);
                 } else if (actionType === "event") {
                     const networkInfo = await connectToPeer(identityName, channelName, msg.payload.orgName, msg.payload.peerName, connectionProfile, msg.payload.walletLocation);
-                    result = await subscribeToEvent(networkInfo.peer, networkInfo.channel, contractName, msg.payload.eventName, 
-                    msg.payload.startBlock, msg.payload.endBlock, node, msg, msg.payload.timeout);
+                    result = await subscribeToEvent(networkInfo.peer, networkInfo.channel, contractName, msg.payload.eventName,
+                        msg.payload.startBlock, msg.payload.endBlock, node, msg, msg.payload.timeout);
                 } else if (actionType === "block") {
                     const networkInfo = await connectToPeer(identityName, channelName, msg.payload.orgName, msg.payload.peerName, connectionProfile, msg.payload.walletLocation);
                     result = await queryBlock(networkInfo.channel, msg.payload);
@@ -352,10 +365,10 @@ module.exports = function (RED) {
     RED.nodes.registerType('fabric-mid', FabricMidNode);
 
     /**
-        * Create an in node
-        * @param {object} config The configuration set on the node
-        * @constructor
-        */
+     * Create an in node
+     * @param {object} config The configuration set on the node
+     * @constructor
+     */
     function FabricInNode(config) {
         let node = this;
         RED.nodes.createNode(node, config);
@@ -393,4 +406,3 @@ module.exports = function (RED) {
     }
     RED.nodes.registerType('fabric-in', FabricInNode);
 };
-

--- a/nodes/fabric.js
+++ b/nodes/fabric.js
@@ -198,6 +198,16 @@ module.exports = function (RED) {
         node.log("Registered event listener");
     }
 
+
+    //todo signature
+    async function queryBlock(channel, payload) {
+        return await channel.queryBlock(payload.blockNumber);
+    }
+
+    async function queryTransaction(channel, transactionId) {
+        return await channel.queryTransaction(transactionId);
+    }
+
     /**
  *
  * @param {string} identityName identityName
@@ -318,6 +328,16 @@ module.exports = function (RED) {
                     const networkInfo = await connectToPeer(identityName, channelName, msg.payload.orgName, msg.payload.peerName, connectionProfile, msg.payload.walletLocation);
                     result = await subscribeToEvent(networkInfo.peer, networkInfo.channel, contractName, msg.payload.eventName, 
                     msg.payload.startBlock, msg.payload.endBlock, node, msg, msg.payload.timeout);
+                } else if (actionType === "block") {
+                    const networkInfo = await connectToPeer(identityName, channelName, msg.payload.orgName, msg.payload.peerName, connectionProfile, msg.payload.walletLocation);
+                    result = await queryBlock(networkInfo.channel, msg.payload);
+                    msg.payload = result;
+                    node.send(msg);
+                } else if (actionType === "transaction") {
+                    const networkInfo = await connectToPeer(identityName, channelName, msg.payload.orgName, msg.payload.peerName, connectionProfile, msg.payload.walletLocation);
+                    result = await queryTransaction(networkInfo.channel, msg.payload.transactionId);
+                    msg.payload = result;
+                    node.send(msg);
                 }
             } catch (error) {
                 node.status({ fill: 'red', shape: 'dot', text: 'Error' });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-fabric",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Hyperledger Fabric nodes for node-red",
     "dependencies": {
         "fabric-network": "1.4.0",


### PR DESCRIPTION
# fabric-config node
Identity name and display name of the configuration are separated, allowing the user to insert a custom configuration name. This is useful in case the user uses identities from two organizations but with the same name (org1 admin and org2 admin for example). Previously, we could only see two "admin" configurations, forcing us to open the configuration to check which config correspond to which org.

# fabric-mid node

##Dynamic configuration
This node now handles dynamic configuration. It can be configured via the `msg.payload` object. 
Any configuration parameter passed to the msg.payload object will overwrite any manual configuration of the node.
For the full list of the configuration parameters, depending on what action the node must perform, please check node description

## Submit and Evaluate transaction
No change. They still use `fabric-network 1.4.0`

## Listen for event(s)

It uses `fabric-client 1.4.0` 

This node can listen for events. There are two "modes" of listening. This mode can be set with the timeout configuration parameter.

The default mode is `timeout = true;`

### Listen for ever

`timeout = false`

If timeout is false, the listener never disconnect/unregister and keep listening. All the events are sent one by one to the next node in `msg.payload`.

**Warning** : If you specified an interval with an end block, the listener **WILL NOT** disconect or unregister. If an interval with an end block is specified, it is preferable to set `timeout = true`.

### Listen "not for ever"

This is the default mode, with `timeout = true`.

The listener reset every time a transaction is found. The timeout's value is 2 seconds.

The timeout is needed because of a bug with the listener and because of the way it works.
More information here: https://jira.hyperledger.org/browse/FABN-1207

The events are sent to the next node all together in an array in `msg.payload`.

## Query world state

The mid node can now query the world state. This uses `fabric-client 1.4.0`.

## Query block

The mid node can now query a block in the ledger. Block is queried by block number.
This uses `fabric-client 1.4.0`.

## Query transaction

The mid node can now query a transaction in the ledger. Transaction is queried by transaction ID.
This uses `fabric-client 1.4.0`.